### PR TITLE
Cleanup + Change battery computations + Set cloro to NaN when missing

### DIFF
--- a/custom_components/ble_yc01/BLE_YC01/__init__.py
+++ b/custom_components/ble_yc01/BLE_YC01/__init__.py
@@ -1,4 +1,4 @@
-"""Parser for RD200 BLE advertisements."""
+"""Parser for BLE-YC01 BLE advertisements."""
 from __future__ import annotations
 
 from .parser import YC01BluetoothDeviceData, YC01Device

--- a/custom_components/ble_yc01/BLE_YC01/__init__.py
+++ b/custom_components/ble_yc01/BLE_YC01/__init__.py
@@ -1,4 +1,4 @@
-"""Parser for BLE-YC01 BLE advertisements."""
+"""Parser for YC01 BLE advertisements."""
 from __future__ import annotations
 
 from .parser import YC01BluetoothDeviceData, YC01Device

--- a/custom_components/ble_yc01/BLE_YC01/const.py
+++ b/custom_components/ble_yc01/BLE_YC01/const.py
@@ -1,1 +1,4 @@
 """Constants for YC01 BLE parser"""
+
+BATT_100 = 3190
+BATT_0 = 1950

--- a/custom_components/ble_yc01/BLE_YC01/const.py
+++ b/custom_components/ble_yc01/BLE_YC01/const.py
@@ -1,3 +1,1 @@
-"""Constants for RD200 BLE parser"""
-
-BQ_TO_PCI_MULTIPLIER = 0.027
+"""Constants for YC01 BLE parser"""

--- a/custom_components/ble_yc01/BLE_YC01/parser.py
+++ b/custom_components/ble_yc01/BLE_YC01/parser.py
@@ -118,7 +118,7 @@ class YC01BluetoothDeviceData:
         device.sensors["TDS"] = self.decode_position(decodedData,7)
         
         cloro = self.decode_position(decodedData,11)
-        if cloro == 65536: cloro = float("nan")
+        if cloro == 65535: cloro = float("nan")
         device.sensors["cloro"] = cloro / 10.0
 
         device.sensors["pH"] = self.decode_position(decodedData,3) / 100.0 

--- a/custom_components/ble_yc01/BLE_YC01/parser.py
+++ b/custom_components/ble_yc01/BLE_YC01/parser.py
@@ -17,8 +17,10 @@ from bleak import BleakClient, BleakError
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import establish_connection
 
-#from .const import (
-#)
+from .const import (
+    BATT_100, BATT_0
+)
+
 
 READ_UUID = "0000ff02-0000-1000-8000-00805f9b34fb"
 
@@ -105,17 +107,25 @@ class YC01BluetoothDeviceData:
 
         backlight_status = (decodedData[17] & 0x0F) >> 3
 
-        device.sensors["battery"] = self.decode_position(decodedData,15) / 31.9
+        battery = round(100 * (self.decode_position(decodedData,15) - BATT_0) / (BATT_100 - BATT_0))
+        battery = min(max(0, battery), 100)
+        device.sensors["battery"] = battery
+
         ec = self.decode_position(decodedData,5)
         device.sensors["EC"] = ec
         device.sensors["salt"] = ec * 0.55
         
         device.sensors["TDS"] = self.decode_position(decodedData,7)
-        device.sensors["cloro"] = self.decode_position(decodedData,11) / 10
         
-        device.sensors["pH"] = self.decode_position(decodedData,3)/100.0 
+        cloro = self.decode_position(decodedData,11) / 10
+        if cloro == 6553.6: cloro = float("nan")
+        device.sensors["cloro"] = cloro
+
+        device.sensors["pH"] = self.decode_position(decodedData,3) / 100.0 
+		
         device.sensors["ORP"] = self.decode_position(decodedData,9) / 1000.0
-        device.sensors["temperature"] = self.decode_position(decodedData,13)/10.0
+		
+        device.sensors["temperature"] = self.decode_position(decodedData,13) / 10.0
         
         #fcAdjust = 0 
         #device.sensors["freeChlorine"] = round( 0.23 * (1 - fcAdjust) * (14 - ph) ** (1/(400 - orp))*(ph - 4.1) ** ( (orp - 516)/145) + 10.0 ** ( (orp + ph * 70 - 1282 ) / 40 ), 1 );  
@@ -143,3 +153,4 @@ class YC01BluetoothDeviceData:
         await client.disconnect()
 
         return device
+																	 

--- a/custom_components/ble_yc01/BLE_YC01/parser.py
+++ b/custom_components/ble_yc01/BLE_YC01/parser.py
@@ -17,9 +17,8 @@ from bleak import BleakClient, BleakError
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import establish_connection
 
-from .const import (
-    BQ_TO_PCI_MULTIPLIER,
-)
+#from .const import (
+#)
 
 READ_UUID = "0000ff02-0000-1000-8000-00805f9b34fb"
 

--- a/custom_components/ble_yc01/BLE_YC01/parser.py
+++ b/custom_components/ble_yc01/BLE_YC01/parser.py
@@ -117,9 +117,9 @@ class YC01BluetoothDeviceData:
         
         device.sensors["TDS"] = self.decode_position(decodedData,7)
         
-        cloro = self.decode_position(decodedData,11) / 10
-        if cloro == 6553.6: cloro = float("nan")
-        device.sensors["cloro"] = cloro
+        cloro = self.decode_position(decodedData,11)
+        if cloro == 65536: cloro = float("nan")
+        device.sensors["cloro"] = cloro / 10.0
 
         device.sensors["pH"] = self.decode_position(decodedData,3) / 100.0 
 		

--- a/custom_components/ble_yc01/__init__.py
+++ b/custom_components/ble_yc01/__init__.py
@@ -1,4 +1,4 @@
-"""The OPAL BLE integration."""
+"""The YC01 BLE integration."""
 from __future__ import annotations
 
 from datetime import timedelta
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up OPAL BLE device from a config entry."""
+    """Set up YC01 BLE device from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     address = entry.unique_id
 
@@ -33,10 +33,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ble_device = bluetooth.async_ble_device_from_address(hass, address)
 
     if not ble_device:
-        raise ConfigEntryNotReady(f"Could not find OPAL device with address {address}")
+        raise ConfigEntryNotReady(f"Could not find YC01 device with address {address}")
 
     async def _async_update_method():
-        """Get data from OPAL BLE."""
+        """Get data from YC01 BLE."""
         ble_device = bluetooth.async_ble_device_from_address(hass, address)
         yc01 = YC01BluetoothDeviceData(_LOGGER)
 

--- a/custom_components/ble_yc01/const.py
+++ b/custom_components/ble_yc01/const.py
@@ -1,8 +1,5 @@
-"""Constants for RD200 BLE."""
+"""Constants for YC01 BLE."""
 
 DOMAIN = "ble_yc01"
 
-VOLUME_BECQUEREL = "Bq/m³"
-VOLUME_PICOCURIE = "pCi/L"
-
-DEFAULT_SCAN_INTERVAL = 600
+DEFAULT_SCAN_INTERVAL = 1800

--- a/custom_components/ble_yc01/manifest.json
+++ b/custom_components/ble_yc01/manifest.json
@@ -9,8 +9,8 @@
   "codeowners": ["@jdeath"],	
   "config_flow": true,
   "dependencies": ["bluetooth_adapters"],
-  "documentation": "https://www.github.com/jdeath/BLE_YC01",
+  "documentation": "https://www.github.com/jdeath/BLE-YC01",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/jdeath/BLE_YC01/issues",
+  "issue_tracker": "https://github.com/jdeath/BLE-YC01/issues",
   "version": "1.0"
 }

--- a/custom_components/ble_yc01/sensor.py
+++ b/custom_components/ble_yc01/sensor.py
@@ -13,13 +13,9 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
-    LIGHT_LUX,
     PERCENTAGE,
-    UnitOfPressure,
     UnitOfTemperature,
-    UnitOfTime,
     UnitOfElectricPotential,
     CONDUCTIVITY,
 )

--- a/custom_components/ble_yc01/sensor.py
+++ b/custom_components/ble_yc01/sensor.py
@@ -34,7 +34,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
-from .const import DOMAIN, VOLUME_BECQUEREL, VOLUME_PICOCURIE
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
I made a few edits to remove the previous references to OPAL and RD200, and fixed a typo ("_" instead of "-" in the URL of the manifest)

I changed the logic for the battery computations, based on the issue # 4 by dwmw2.
BATT_100 is 3190 and BATT_0 is 1950. Both values may require some adjustment.
If BATT_0 is set to 0, this returns to the previous calculations.

I set cloro to NaN in case the underlying value is 65536 (and the device reports "---"), in order not to send the 6553.6 value to HA.
