### PR TITLE
Fix missing chlorine error

### DIFF
--- a/custom_components/ble_yc01/BLE_YC01/parser.py
+++ b/custom_components/ble_yc01/BLE_YC01/parser.py
@@ -118,8 +118,10 @@ class YC01BluetoothDeviceData:
         device.sensors["TDS"] = self.decode_position(decodedData,7)
         
         cloro = self.decode_position(decodedData,11)
-        if cloro == 65535: cloro = float("nan")
-        device.sensors["cloro"] = cloro / 10.0
+        if cloro == 65535:
+          device.sensors["cloro"] = None
+        else:
+          device.sensors["cloro"] = cloro / 10.0
 
         device.sensors["pH"] = self.decode_position(decodedData,3) / 100.0 
 		

--- a/custom_components/ble_yc01/sensor.py
+++ b/custom_components/ble_yc01/sensor.py
@@ -77,7 +77,6 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:battery",
     ),
     "cloro": SensorEntityDescription(
         key="cloro",

--- a/custom_components/ble_yc01/sensor.py
+++ b/custom_components/ble_yc01/sensor.py
@@ -51,7 +51,7 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
     ),
     "ORP": SensorEntityDescription(
         key="ORP",
-        name="Oxidation-reduction potential",
+        name="Oxidation-Reduction Potential",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.VOLTAGE,


### PR DESCRIPTION
Changed from NaN to None for missing chlorine values (reported as 65535)
 - NaN: The entity is not created in HA, resulting in an error
 - None: The entity is created, with the value "unknown"