### PR TITLE
Change chloro to 0 instead of None for fixing lovelace cards

### DIFF
--- a/custom_components/ble_yc01/BLE_YC01/parser.py
+++ b/custom_components/ble_yc01/BLE_YC01/parser.py
@@ -119,7 +119,7 @@ class YC01BluetoothDeviceData:
         
         cloro = self.decode_position(decodedData,11)
         if cloro == 65535:
-          device.sensors["cloro"] = None
+          device.sensors["cloro"] = 0
         else:
           device.sensors["cloro"] = cloro / 10.0
 


### PR DESCRIPTION
Hi, i think its better to define '0' instead of None. Some cards are giving invalid number issues, like the Gauge card ...