### PR TITLE
Update sensor.py HA Warning UnitOfConductivity.MICROSIEMENS deprecated use UnitOfConductivity.MICROSIEMENS_PER_CM

### DIFF
--- a/custom_components/ble_yc01/sensor.py
+++ b/custom_components/ble_yc01/sensor.py
@@ -38,7 +38,7 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
     "EC": SensorEntityDescription(
         key="EC",
         name="Electrical Conductivity",
-        native_unit_of_measurement=UnitOfConductivity.MICROSIEMENS,
+        native_unit_of_measurement=UnitOfConductivity.MICROSIEMENS_PER_CM,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash-triangle-outline",
     ),


### PR DESCRIPTION
Change from
native_unit_of_measurement=UnitOfConductivity.MICROSIEMENS, to
native_unit_of_measurement=UnitOfConductivity.MICROSIEMENS_PER_CM,